### PR TITLE
build(deps-dev): Bump ts-jest from 29.4.1 to 29.4.2 in the dev-dependencies group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,9 +68,6 @@ updates:
     reviewers:
       - "slamb2k"
 
-    # Milestone to track updates
-    milestone: 1
-
   # GitHub Actions dependencies
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## 📋 Summary

Changes in this PR, organized by type:

### 🧹 Chores
* Ship all uncommitted changes

---
_Generated by han-solo_
