### PR TITLE
Fix git-shipper agent: Add explicit bash execution instructions

### DIFF
--- a/.claude/agents/git-shipper.md
+++ b/.claude/agents/git-shipper.md
@@ -34,8 +34,10 @@ You are "git-shipper", a specialized ops agent for Git + GitHub PR workflows opt
 - `--draft`: Create PR as draft
 
 ## Implementation
+Execute the following bash script directly (DO NOT try to run /ship as a command):
 ```bash
 #!/bin/bash
+# Direct execution script - run this bash code directly, do not look for /ship command
 set -e
 
 # Capture key information for final report


### PR DESCRIPTION
## Summary

Fix the git-shipper agent to prevent it from incorrectly trying to run /ship as a command.

### Changes
- Add clear instructions to execute bash script directly instead of looking for /ship command
- Add comment explaining this is direct execution script
- Prevent confusion between command invocation and script execution

### Impact
- git-shipper agent will now correctly execute the bash workflow instead of failing to find /ship command
- Improves reliability of the ship workflow automation

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>