### PR TITLE
Improve SKIP_BANNER handling with universal banner control

### DIFF
--- a/.claude/scripts/block-text.sh
+++ b/.claude/scripts/block-text.sh
@@ -4,6 +4,11 @@
 # Based on the lolcat implementation: https://github.com/busyloop/lolcat
 # Usage: ./block-text.sh "YOUR TEXT"
 
+# Check if banner should be skipped (used by automated tools to avoid duplicate banners)
+if [[ "${SKIP_BANNER}" == "1" ]]; then
+    exit 0
+fi
+
 declare -A letters
 
 # Define each letter as 3 lines (removed trailing spaces for tighter spacing)


### PR DESCRIPTION
This PR improves the SKIP_BANNER handling by:

1. **Added SKIP_BANNER check directly in block-text.sh** - Creates a cleaner single point of control for banner display
2. **Removed redundant wrapper check from ship-core.sh** - Since block-text.sh now handles it, the wrapper-specific logic is no longer needed

## Benefits
- **Universal control**: Any script can now use SKIP_BANNER=1 to suppress banner display
- **Cleaner architecture**: Single point of control in block-text.sh instead of scattered checks
- **More maintainable**: Reduces duplication and makes banner control consistent across all scripts

## Implementation
The SKIP_BANNER check is now centralized in the block-text.sh function itself, making it work universally for any script that uses the banner display function.